### PR TITLE
Switch back from usm_device to sycl::buffer

### DIFF
--- a/test/unit_tests_oneapi.cpp
+++ b/test/unit_tests_oneapi.cpp
@@ -1,6 +1,3 @@
-// #include <fstream>
-// #include <iomanip>
-
 #include <oneapi/dpl/execution>
 #include <sycl/sycl.hpp>
 
@@ -28,17 +25,14 @@ TEMPLATE_TEST_CASE( "generate_table() x3 - oneAPI", "[oneAPI][10Kx3]", float, do
 {   typedef TestType T;
     const auto nr{10'000}, nc{3};
     sycl::queue q;
-    T* vrs = sycl::malloc_device<T>(nr * nc, q);
-    T* vbs = sycl::malloc_device<T>(nr * nc, q);
-    T* r = sycl::malloc_device<T>(nc * 2, q);
-    std::vector<T> vrsh(nr * nc), rh
+    std::vector<T> vrs(nr * nc), r
     {   T(0), T( 1), T(  10)  // mins
     ,   T(1), T(10), T(1000)  // maxs
     };
 
     one4all::generate_table_rs<pcg32>
-    (   std::begin(rh)
-    ,   std::begin(vrsh)
+    (   std::begin(r)
+    ,   std::begin(vrs)
     ,   nr
     ,   nc
     ,   seed_pi
@@ -50,56 +44,51 @@ TEMPLATE_TEST_CASE( "generate_table() x3 - oneAPI", "[oneAPI][10Kx3]", float, do
         (   dpl::counting_iterator<size_t>(0)
         ,   dpl::counting_iterator<size_t>(nr * nc)
         ,   [&] (size_t i)
-            { return ( vrsh[i] >= rh[i % nc] && vrsh[i] < rh[ (i % nc) + nc] ); }
+            { return ( vrs[i] >= r[i % nc] && vrs[i] < r[ (i % nc) + nc] ); }
         ) );
     }
 
     SECTION("block_splitting")
-    {   q.memcpy(r, rh.data(), nc * 2 * sizeof(T));
+    {   sycl::buffer<T> dr(r), dvbs{sycl::range(nr * nc)};
         one4all::oneapi::generate_table<pcg32>
-        (   r
-        ,   vbs
+        (   dpl::begin(dr)
+        ,   dpl::begin(dvbs)
         ,   nr
         ,   nc
         ,   seed_pi
         ,   q
         ).wait();
-        q.memcpy(vrs, vrsh.data(), nr * nc * sizeof(T));
+
+        sycl::host_accessor vbs{dvbs, sycl::read_only};
 
         CHECK( std::all_of(
-            oneapi::dpl::execution::make_device_policy(q)
-        ,   dpl::counting_iterator<size_t>(0)
+            dpl::counting_iterator<size_t>(0)
         ,   dpl::counting_iterator<size_t>(nr * nc)
-        ,   [=] (size_t i)
+        ,   [&] (size_t i)
             { return ( std::abs(vrs[i] - vbs[i]) < 0.0001 ); }
         ) );
     }
-
-    sycl::free(r, q); sycl::free(vrs, q); sycl::free(vbs, q);
 }
 
 TEMPLATE_TEST_CASE( "scale_table() x8 - oneapi", "[1Kx8]", float, double )
 {   typedef TestType T;
     const auto nr{1000}, nc{8};
     sycl::queue q;
-    T* b = sycl::malloc_device<T>(nr * nc, q);
-    T* r = sycl::malloc_device<T>(nc * 2, q);
-    std::vector<T> rh
+    std::vector<T> r
     {   T(-10), T(-5), T(-1), T(0), T(1), T( 5), T(10), T(15)  // mins
     ,   T( -5), T(-1), T( 0), T(1), T(5), T(10), T(15), T(20)  // maxs
     };
+    sycl::buffer<T> b{nr * nc}, dr(r);
 
-    q.memcpy(r, rh.data(), nc * 2 * sizeof(T));
     one4all::oneapi::generate_table<pcg32>
-    (   r
-    ,   b
+    (   dpl::begin(dr)
+    ,   dpl::begin(b)
     ,   nr
     ,   nc
     ,   seed_pi
     ).wait();
 
-    sycl::usm_allocator<T,sycl::usm::alloc::shared> alloc(q);
-    std::vector<T, decltype(alloc)> bsr(nr * nc, alloc);
+    std::vector<T> bsr(nr * nc);
     std::ifstream file(ONE4ALL_TEST_DATA_PATH"/scale_table_ref.txt");
     std::copy
     (   std::istream_iterator<T>(file)
@@ -107,25 +96,23 @@ TEMPLATE_TEST_CASE( "scale_table() x8 - oneapi", "[1Kx8]", float, double )
     ,   std::begin(bsr)
     );
 
-    T* bs = sycl::malloc_device<T>(nr * nc, q);
+    sycl::buffer<T> bs{nr * nc}, dbsr(bsr);
     one4all::oneapi::scale_table
-    (   r
-    ,   b
-    ,   bs
+    (   dpl::begin(dr)
+    ,   dpl::begin(b)
+    ,   dpl::begin(bs)
     ,   nr
     ,   nc
     ,   T(-1.0), T(1.0)
     ,   q
     ).wait();
 
-    auto begin = dpl::make_zip_iterator(std::begin(bsr), bs);
+    auto begin = dpl::make_zip_iterator(dpl::begin(dbsr), dpl::begin(bs));
     CHECK( std::all_of
-    (   oneapi::dpl::execution::make_device_policy(q)
+    (   dpl::execution::make_device_policy(q)
     ,   begin
     ,   begin + (nr * nc)
     ,   [] (auto t)
         { return ( std::abs(std::get<0>(t) - std::get<1>(t)) < 0.001 ); }
     )   );
-
-    sycl::free(r, q); sycl::free(b, q); sycl::free(bs, q);
 }


### PR DESCRIPTION
Switch back from usm_device to sycl::buffer to have more consistent interface with other APIs.